### PR TITLE
Bug fixes: callable fields and pagination in filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,21 @@ class AccountListView(LoginRequiredMixin, SmartListMixin, ListView):
 
 ## Development
 
-### Set up
+### Setup
 
-To set up the project locally run the below commands form the repository root:
+To set up the project locally run the below commands from the repository root:
 
 ```bash
-$ python3 -m venv .venv  # if you're on Python 2 create virtualenv in another appropraite way
+$ python3 -m venv .venv  # if you're on Python 2 create virtualenv in another, appropriate way
 $ source .venv/bin/activate
 $ pip install -r testproject/requirements.txt
-$ ./manage.py seed_data  # this will create a couple of objects to list
+$ ./manage.py seed_data  # this will create objects for list view
 $ ./manage.py runserver  
 ```
 
 Afterwards go to `http://localhost:8000` and see an example of smart list usage.
 
-> NOTE: the versions in `requirements.txt` file are not pinned. If you wish to install specific versions
+> NOTE: package versions in `requirements.txt` file are not pinned. If you wish to install specific versions
 > you need to edit the file accordingly.
 
 ### Contributing 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This will give you a click-to-sort table with pagination. All you have to do is 
 ```
 **The built-in templates are bootstrap 3 compatible - but override them easily (by positioning the apps in INSTALLED_APPS) to fit your own needs**
 
-# Other features
+## Other features
 
 In case:
 1. You need custom column name you can pass tuple with two strings.
@@ -45,7 +45,6 @@ from django.template.loader import get_template
 
 def render_menu(obj):
     # Do sth with object
-    print obj
     context = {
         'obj': obj,
         'other_context': 'Lorem ipsum' * obj.count 
@@ -68,7 +67,32 @@ class AccountListView(LoginRequiredMixin, SmartListMixin, ListView):
     ]
 ```
 
-### License
+## Development
+
+### Set up
+
+To set up the project locally run the below commands form the repository root:
+
+```bash
+$ python3 -m venv .venv  # if you're on Python 2 create virtualenv in another appropraite way
+$ source .venv/bin/activate
+$ pip install -r testproject/requirements.txt
+$ ./manage.py seed_data  # this will create a couple of objects to list
+$ ./manage.py runserver  
+```
+
+Afterwards go to `http://localhost:8000` and see an example of smart list usage.
+
+> NOTE: the versions in `requirements.txt` file are not pinned. If you wish to install specific versions
+> you need to edit the file accordingly.
+
+### Contributing 
+
+To contribute to this project fork the repository and make a pull request against the `master` branch.
+
+Remember to write tests for your changes!
+
+## License
 
 MIT License
 

--- a/smart_lists/helpers.py
+++ b/smart_lists/helpers.py
@@ -35,7 +35,6 @@ class TitleFromModelFieldMixin(object):
 
 
 class QueryParamsMixin(object):
-
     def get_url_with_query_params(self, new_query_dict, without=None):
         without = without or []
         query = dict(self.query_params).copy()

--- a/smart_lists/helpers.py
+++ b/smart_lists/helpers.py
@@ -67,6 +67,7 @@ class SmartListField(object):
             value = self.object.get(self.column.field_name)
         elif callable(field):
             value = field() if getattr(field, 'do_not_call_in_templates', False) else field
+            value = field if getattr(field, 'do_not_call_in_templates', False) else field()
         else:
             display_function = getattr(self.object, 'get_%s_display' % self.column.field_name, False)
             value = display_function() if display_function else field

--- a/testproject/management/commands/seed_data.py
+++ b/testproject/management/commands/seed_data.py
@@ -4,7 +4,6 @@ from testproject.models import SampleModel, CATEGORY_CHOICES
 
 
 class Command(BaseCommand):
-
     def handle(self, *args, **options):
         for i, (category, _) in enumerate(CATEGORY_CHOICES):
             for y in range(5):

--- a/testproject/management/commands/seed_data.py
+++ b/testproject/management/commands/seed_data.py
@@ -1,0 +1,13 @@
+from django.core.management import BaseCommand
+
+from testproject.models import SampleModel, CATEGORY_CHOICES
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        for i, (category, _) in enumerate(CATEGORY_CHOICES):
+            for y in range(5):
+                title = "Example title {}{}".format(i, y)
+                SampleModel.objects.get_or_create(title=title, category=category)
+        self.stdout("Example data created successfully.")

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -1,0 +1,2 @@
+django
+six

--- a/testproject/templates/testproject/example_column_template.html
+++ b/testproject/templates/testproject/example_column_template.html
@@ -1,0 +1,1 @@
+{{ obj.friendly_category|upper }}

--- a/testproject/templates/testproject/samplemodel_list.html
+++ b/testproject/templates/testproject/samplemodel_list.html
@@ -1,0 +1,32 @@
+{% load smart_list %}
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Smart list example</title>
+
+    <!-- Bootstrap -->
+   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+  <div class="container">
+    <h1>Smart list usage example</h1>
+    {% smart_list %}
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+  </div>
+  </body>
+</html>

--- a/testproject/tests.py
+++ b/testproject/tests.py
@@ -95,6 +95,7 @@ class SmartListTestCase(TestCase):
     def test_get_column_from_method(self):
         smart_list = SmartList(SampleModel.objects.all(), **{'list_display': ('some_display_method',)})
         self.assertEqual('Some Display Method', smart_list.columns[0].get_title())
+        self.assertEqual('I just love django-smart-lists! blog_post', smart_list.items[0].fields()[0].get_value())
 
     def test_search(self):
         test = SampleModel.objects.create(title='test')

--- a/testproject/tests.py
+++ b/testproject/tests.py
@@ -216,3 +216,15 @@ class SmartListTestCase(TestCase):
         smart_list_item_field_with_custom_render = smart_list.items[-1].fields()[-1].get_value()
 
         self.assertEqual(render_column_function(SampleModel.objects.last()), smart_list_item_field_with_custom_render)
+
+    def test_new_filter_clears_pagination(self):
+        request = self.factory.get('/smart-lists/?page=2&o=1&category=blog_post')
+        smart_list = SmartList(
+            SampleModel.objects.all(),
+            list_display=('title', 'category'),
+            list_filter=('title', 'category'),
+            query_params=request.GET,
+        )
+        fltr = smart_list.filters[0]
+        url = fltr.get_values()[0].get_url()
+        self.assertEqual(set(url[1:].split('&')), set(['o=1', 'category=blog_post']))

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -18,7 +18,4 @@ from django.contrib import admin
 
 from testproject import views
 
-urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'', views.SampleModelListView.as_view())
-]
+urlpatterns = [url(r'^admin/', admin.site.urls), url(r'', views.SampleModelListView.as_view())]

--- a/testproject/urls.py
+++ b/testproject/urls.py
@@ -16,4 +16,9 @@ Including another URLconf
 from django.conf.urls import url
 from django.contrib import admin
 
-urlpatterns = [url(r'^admin/', admin.site.urls)]
+from testproject import views
+
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+    url(r'', views.SampleModelListView.as_view())
+]

--- a/testproject/views.py
+++ b/testproject/views.py
@@ -1,0 +1,26 @@
+from django.utils import timezone
+from django.views.generic import ListView
+from django.utils.safestring import SafeText
+
+from smart_lists.helpers import render_column_template
+from smart_lists.mixins import SmartListMixin
+
+from testproject.models import SampleModel
+
+
+def example_render_function(obj):
+    return SafeText(timezone.now())
+
+
+class SampleModelListView(SmartListMixin, ListView):
+    model = SampleModel
+    paginate_by = 5
+    ordering_allowed_fields = ['title']
+    list_display = (
+        'title',
+        'category',
+        'some_display_method',
+        (render_column_template('testproject/example_column_template.html'), 'Upper filter used for field'),
+        (example_render_function, "Time")
+    )
+    list_filter = ("category",)

--- a/testproject/views.py
+++ b/testproject/views.py
@@ -21,6 +21,6 @@ class SampleModelListView(SmartListMixin, ListView):
         'category',
         'some_display_method',
         (render_column_template('testproject/example_column_template.html'), 'Upper filter used for field'),
-        (example_render_function, "Time")
+        (example_render_function, "Time"),
     )
     list_filter = ("category",)


### PR DESCRIPTION
This PR fixes two bugs:

1. Callable fields are now actually being called (for now the name of a method was rendered)
2. When selecting a filter the `page` param is removed from query which prevents 404 errors.

Additionally it adds a project setup changes that enable to quickly setup a local fork and see smart lists in action in the browser.