### PR TITLE
Add changelog

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -1,0 +1,288 @@
+# -*- coding: utf-8; mode: python -*-
+##
+## Format
+##
+##   ACTION: [AUDIENCE:] COMMIT_MSG [!TAG ...]
+##
+## Description
+##
+##   ACTION is one of 'chg', 'fix', 'new'
+##
+##       Is WHAT the change is about.
+##
+##       'chg' is for refactor, small improvement, cosmetic changes...
+##       'fix' is for bug fixes
+##       'new' is for new features, big improvement
+##
+##   AUDIENCE is optional and one of 'dev', 'usr', 'pkg', 'test', 'doc'
+##
+##       Is WHO is concerned by the change.
+##
+##       'dev'  is for developpers (API changes, refactors...)
+##       'usr'  is for final users (UI changes)
+##       'pkg'  is for packagers   (packaging changes)
+##       'test' is for testers     (test only related changes)
+##       'doc'  is for doc guys    (doc only changes)
+##
+##   COMMIT_MSG is ... well ... the commit message itself.
+##
+##   TAGs are additionnal adjective as 'refactor' 'minor' 'cosmetic'
+##
+##       They are preceded with a '!' or a '@' (prefer the former, as the
+##       latter is wrongly interpreted in github.) Commonly used tags are:
+##
+##       'refactor' is obviously for refactoring code only
+##       'minor' is for a very meaningless change (a typo, adding a comment)
+##       'cosmetic' is for cosmetic driven change (re-indentation, 80-col...)
+##       'wip' is for partial functionality but complete subfunctionality.
+##
+## Example:
+##
+##   new: usr: support of bazaar implemented
+##   chg: re-indentend some lines !cosmetic
+##   new: dev: updated code to be compatible with last version of killer lib.
+##   fix: pkg: updated year of licence coverage.
+##   new: test: added a bunch of test around user usability of feature X.
+##   fix: typo in spelling my name in comment. !minor
+##
+##   Please note that multi-line commit message are supported, and only the
+##   first line will be considered as the "summary" of the commit message. So
+##   tags, and other rules only applies to the summary.  The body of the commit
+##   message will be displayed in the changelog without reformatting.
+
+
+##
+## ``ignore_regexps`` is a line of regexps
+##
+## Any commit having its full commit message matching any regexp listed here
+## will be ignored and won't be reported in the changelog.
+##
+
+ignore_regexps = [
+    r'@minor', r'!minor',
+    r'@cosmetic', r'!cosmetic',
+    r'@refactor', r'!refactor',
+    r'@wip', r'!wip',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[p|P]kg:',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[d|D]ev:',
+    r'^(.{3,3}\s*:)?\s*[fF]irst commit.?\s*$',
+    r'^[bB]ump(ed)?.*', r'[nN]ew version.*', r'[nN]ew release',
+    r'^Revert',
+    r'^$',  # ignore commits with empty messages
+]
+
+## ``section_regexps`` is a list of 2-tuples associating a string label and a
+## list of regexp
+##
+## Commit messages will be classified in sections thanks to this. Section
+## titles are the label, and a commit is classified under this section if any
+## of the regexps associated is matching.
+##
+## Please note that ``section_regexps`` will only classify commits and won't
+## make any changes to the contents. So you'll probably want to go check
+## ``subject_process`` (or ``body_process``) to do some changes to the subject,
+## whenever you are tweaking this variable.
+##
+section_regexps = [
+    ('New', [
+        r'^[nN]ew\s*:?\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+        r'[Aa]dd'
+    ]),
+    ('Changes', [
+        r'^[cC]hg\s*:?\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+    ]),
+    ('Fix', [
+        r'^[fF]ix\s*:?\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+        r'fixes',
+    ]),
+
+    ('Other', None  ## Match all lines
+     ),
+
+]
+
+## ``body_process`` is a callable
+##
+## This callable will be given the original body and result will
+## be used in the changelog.
+##
+## Available constructs are:
+##
+##   - any python callable that take one txt argument and return txt argument.
+##
+##   - ReSub(pattern, replacement): will apply regexp substitution.
+##
+##   - Indent(chars="  "): will indent the text with the prefix
+##     Please remember that template engines gets also to modify the text and
+##     will usually indent themselves the text if needed.
+##
+##   - Wrap(regexp=r"\n\n"): re-wrap text in separate paragraph to fill 80-Columns
+##
+##   - noop: do nothing
+##
+##   - ucfirst: ensure the first letter is uppercase.
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - final_dot: ensure text finishes with a dot
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - strip: remove any spaces before or after the content of the string
+##
+##   - SetIfEmpty(msg="No commit message."): will set the text to
+##     whatever given ``msg`` if the current text is empty.
+##
+## Additionally, you can `pipe` the provided filters, for instance:
+# body_process = Wrap(regexp=r'\n(?=\w+\s*:)') | Indent(chars="  ")
+# body_process = Wrap(regexp=r'\n(?=\w+\s*:)')
+# body_process = noop
+body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
+
+## ``subject_process`` is a callable
+##
+## This callable will be given the original subject and result will
+## be used in the changelog.
+##
+## Available constructs are those listed in ``body_process`` doc.
+subject_process = (strip |
+                   ReSub(r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n@]*)(@[a-z]+\s+)*$',
+                         r'\4') |
+                   SetIfEmpty("No commit message.") | ucfirst | final_dot)
+
+## ``tag_filter_regexp`` is a regexp
+##
+## Tags that will be used for the changelog must match this regexp.
+##
+tag_filter_regexp = r'^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+
+## ``unreleased_version_label`` is a string or a callable that outputs a string
+##
+## This label will be used as the changelog Title of the last set of changes
+## between last valid tag and HEAD if any.
+unreleased_version_label = "(unreleased)"
+
+## ``output_engine`` is a callable
+##
+## This will change the output format of the generated changelog file
+##
+## Available choices are:
+##
+##   - rest_py
+##
+##        Legacy pure python engine, outputs ReSTructured text.
+##        This is the default.
+##
+##   - mustache(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mustache/*.tpl``.
+##        Requires python package ``pystache``.
+##        Examples:
+##           - mustache("markdown")
+##           - mustache("restructuredtext")
+##
+##   - makotemplate(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mako/*.tpl``.
+##        Requires python package ``mako``.
+##        Examples:
+##           - makotemplate("restructuredtext")
+##
+output_engine = rest_py
+# output_engine = mustache("restructuredtext")
+# output_engine = mustache("markdown")
+# output_engine = makotemplate("restructuredtext")
+
+
+## ``include_merge`` is a boolean
+##
+## This option tells git-log whether to include merge commits in the log.
+## The default is to include them.
+include_merge = False
+
+## ``log_encoding`` is a string identifier
+##
+## This option tells gitchangelog what encoding is outputed by ``git log``.
+## The default is to be clever about it: it checks ``git config`` for
+## ``i18n.logOutputEncoding``, and if not found will default to git's own
+## default: ``utf-8``.
+# log_encoding = 'utf-8'
+
+
+## ``publish`` is a callable
+##
+## Sets what ``gitchangelog`` should do with the output generated by
+## the output engine. ``publish`` is a callable taking one argument
+## that is an interator on lines from the output engine.
+##
+## Some helper callable are provided:
+##
+## Available choices are:
+##
+##   - stdout
+##
+##        Outputs directly to standard output
+##        (This is the default)
+##
+##   - FileInsertAtFirstRegexMatch(file, pattern, idx=lamda m: m.start())
+##
+##        Creates a callable that will parse given file for the given
+##        regex pattern and will insert the output in the file.
+##        ``idx`` is a callable that receive the matching object and
+##        must return a integer index point where to insert the
+##        the output in the file. Default is to return the position of
+##        the start of the matched string.
+##
+##   - FileRegexSubst(file, pattern, replace, flags)
+##
+##        Apply a replace inplace in the given file. Your regex pattern must
+##        take care of everything and might be more complex. Check the README
+##        for a complete copy-pastable example.
+##
+# publish = FileInsertIntoFirstRegexMatch(
+#     "CHANGELOG.rst",
+#     r'/(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n/',
+#     idx=lambda m: m.start(1)
+# )
+# publish = stdout
+
+
+## ``revs`` is a list of callable or a list of string
+##
+## callable will be called to resolve as strings and allow dynamical
+## computation of these. The result will be used as revisions for
+## gitchangelog (as if directly stated on the command line). This allows
+## to filter exaclty which commits will be read by gitchangelog.
+##
+## To get a full documentation on the format of these strings, please
+## refer to the ``git rev-list`` arguments. There are many examples.
+##
+## Using callables is especially useful, for instance, if you
+## are using gitchangelog to generate incrementally your changelog.
+##
+## Some helpers are provided, you can use them::
+##
+##   - FileFirstRegexMatch(file, pattern): will return a callable that will
+##     return the first string match for the given pattern in the given file.
+##     If you use named sub-patterns in your regex pattern, it'll output only
+##     the string matching the regex pattern named "rev".
+##
+##   - Caret(rev): will return the rev prefixed by a "^", which is a
+##     way to remove the given revision and all its ancestor.
+##
+## Please note that if you provide a rev-list on the command line, it'll
+## replace this value (which will then be ignored).
+##
+## If empty, then ``gitchangelog`` will act as it had to generate a full
+## changelog.
+##
+## The default is to use all commits to make the changelog.
+# revs = ["^1.0.3", ]
+# revs = [
+#    Caret(
+#        FileFirstRegexMatch(
+#            "CHANGELOG.rst",
+#            r"(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n")),
+#    "HEAD"
+# ]
+revs = []

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.*venv/
 
 # Spyder project settings
 .spyderproject

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,240 @@
+Changelog
+=========
+
+
+1.0.33 (2019-10-03)
+-------------------
+
+Fix
+~~~
+- Fix string unpacking. [Tadek Teleżyński]
+
+
+1.0.32 (2019-09-30)
+-------------------
+
+Fix
+~~~
+- Fix formatting and typos in readme. [Tadek Teleżyński]
+- Fixes callable field bug. [Tadek Teleżyński]
+
+  The conditional statement in `get_value` was backwards.
+
+Other
+~~~~~
+- Clear pagination when selecting new filter. [Tadek Teleżyński]
+- Enable running a smart list example locally. [Tadek Teleżyński]
+
+  This commit gives an out-of-the-box browser example of
+  smart lists usage. It adds:
+  - management command to create initial data
+  - django view which utilizes different smart lists features
+  - necessary templates, project files etc.
+  - appropriate README section
+
+
+1.0.31 (2019-09-09)
+-------------------
+
+Fix
+~~~
+- Fix filters with pagination. [Michal Simonienko]
+
+
+1.0.30 (2019-07-29)
+-------------------
+- In list_display getter renturn copy of a list. [Michal Simonienko]
+
+
+1.0.29 (2019-07-29)
+-------------------
+
+New
+~~~
+- Add getter for list_display. [Michal Simonienko]
+
+  Add getter for list_display.
+  Add missing imports for type checking.
+
+
+1.0.28 (2019-07-26)
+-------------------
+
+New
+~~~
+- Add black and reformat code. [Michal Simonienko]
+
+  from now on project follows black style guide
+
+Fix
+~~~
+- Fix ordering. [Michal Simonienko]
+- Fix travis exclude. [bartek-biernacki]
+- Fix tests. [bartek-biernacki]
+
+Other
+~~~~~
+- .gitignore and Travis config. [bartek-biernacki]
+- Update README. [Michal Simonienko]
+
+
+1.0.26 (2019-07-17)
+-------------------
+
+New
+~~~
+- Add render_column_template helper. [Michal Simonienko]
+- Add custom rendered custom element. [Michal Simonienko]
+
+  From now on you can pass in list_displays also two element iterables in
+  which first element is a callble that returns html and second element is
+  a label for that column.
+
+Fix
+~~~
+- Fix XSS vulnerability in render_function. [Michal Simonienko]
+
+Other
+~~~~~
+- Make render_function more versatile. [Michal Simonienko]
+
+
+1.0.25 (2019-07-12)
+-------------------
+
+New
+~~~
+- Add labels for columns. [Michal Simonienko]
+
+  From now on in list_display you can pass string or tuple of two
+  strings. First string in a tuple is the field name and second is a label
+  (the name for column).
+
+
+1.0.24 (2019-07-09)
+-------------------
+
+New
+~~~
+- Added Makefile for easy releasing. [Ales Kocjancic]
+
+Fix
+~~~
+- Fix default arguments logic for smart_list templatetag. [Michal
+  Simonienko]
+
+Other
+~~~~~
+- Removed md description since it fails on pypi. [Ales Kocjancic]
+
+
+1.0.23 (2019-06-13)
+-------------------
+
+New
+~~~
+- Add django 2 compatibility. [Krzysztof Bujniewicz]
+
+Other
+~~~~~
+- Moved version into package. [Ales Kocjancic]
+
+
+1.0.22 (2018-09-30)
+-------------------
+- Make sure it works wiht both classes and str. [Kristian Øllegaard]
+- Bugfix. [Kristian Øllegaard]
+
+
+1.0.20 (2018-09-30)
+-------------------
+- Bugfix and more tests. [Kristian Øllegaard]
+
+
+10.0.19 (2018-09-30)
+--------------------
+- Support for custom filters, like the ones found in Django admin.
+  [Kristian Øllegaard]
+- Prettier labels (which are also translated already by Django)
+  [Kristian Øllegaard]
+- Custom classes and grid sizes and fixed tests. [Kristian Øllegaard]
+- Update README.md. [Kristian Øllegaard]
+
+
+1.0.17 (2017-04-28)
+-------------------
+
+Fix
+~~~
+- Fixed test to use q GET parameter. [Mikkel Clausen]
+- Fixed typo in comment. [Mikkel Clausen]
+
+Other
+~~~~~
+- Refactored internals and made choices on filters bold. [Kristian
+  Øllegaard]
+- Support .values() querysets. [Kristian Øllegaard]
+- Removed unused method. [Mikkel Clausen]
+- Smart_lists: fixed code style. [Mikkel Clausen]
+- Smart_lists/helpers: fix for getTitle. [Mikkel Clausen]
+- Smart_lists/helpers: use _meta in getTitle. [Mikkel Clausen]
+- Renamed search GET parameter to q instead of search. [Mikkel Clausen]
+- Cleanup nameing of search_query_value and list_search. [Mikkel
+  Clausen]
+- Implemented django-admin like search including test. [Mikkel Clausen]
+- More tests. [Kristian Øllegaard]
+
+
+10.0.13 (2017-03-14)
+--------------------
+
+Fix
+~~~
+- Fixed readme to use smart_list as template tag instead of smart_lists.
+  [Mikkel Clausen]
+
+Other
+~~~~~
+- Smart_lists/templatetag/smart_list.py: fixed name collision. [Mikkel
+  Clausen]
+
+
+10.0.12 (2017-03-12)
+--------------------
+- Filters !!! [Kristian Øllegaard]
+
+
+10.0.11 (2017-03-12)
+--------------------
+- Ordering on custom list_display functions and short_description.
+  [Kristian Øllegaard]
+
+
+1.0.10 (2017-03-12)
+-------------------
+- Easy multiple sorting and better templates. [Kristian Øllegaard]
+- Redid ordering so it supports multiple columns and uses the same
+  syntax as django admin. [Kristian Øllegaard]
+
+
+1.0.8 (2017-03-12)
+------------------
+
+Fix
+~~~
+- Fixed this packaging mess. [Kristian Øllegaard]
+
+Other
+~~~~~
+- Wrong import. [Kristian Øllegaard]
+- Packaging is hard .. :-) [Kristian Øllegaard]
+- 1.0.1. [Kristian Øllegaard]
+- Packaging. [Kristian Øllegaard]
+- Setup.py. [Kristian Øllegaard]
+- Update README.md. [Kristian Øllegaard]
+- Update README.md. [Kristian Øllegaard]
+- Update README.md. [Kristian Øllegaard]
+- Initial commit / MVP. [Kristian Øllegaard]
+- Initial commit. [Kristian Øllegaard]
+
+

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ git-release:
 	git add ${PROJECT}/__init__.py
 	git commit -m "Bumped version to `cat ${PROJECT}/__init__.py | awk -F '("|")' '{ print($$2)}'`"
 	git tag `cat ${PROJECT}/__init__.py | awk -F '("|")' '{ print($$2)}'`
+	gitchangelog > CHANGELOG.rst
+	git add CHANGELOG.rst
+	git commit --amend --no-edit
+	git tag -f `cat ${PROJECT}/__init__.py | awk -F '("|")' '{ print($$2)}'`
 	git push
 	git push --tags
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ To set up the project locally run the below commands from the repository root:
 $ python3 -m venv .venv  # if you're on Python 2 create virtualenv in another, appropriate way
 $ source .venv/bin/activate
 $ pip install -r testproject/requirements.txt
+$ ./manage.py migrate
 $ ./manage.py seed_data  # this will create objects for list view
 $ ./manage.py runserver  
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+gitchangelog

--- a/testproject/management/commands/seed_data.py
+++ b/testproject/management/commands/seed_data.py
@@ -9,4 +9,4 @@ class Command(BaseCommand):
             for y in range(5):
                 title = "Example title {}{}".format(i, y)
                 SampleModel.objects.get_or_create(title=title, category=category)
-        self.stdout("Example data created successfully.")
+        self.stdout.write("Example data created successfully.")


### PR DESCRIPTION
This provides a changelog using https://github.com/vaab/gitchangelog package.

To generate a changelog, install requirements and run:
```bash
$ gitchangelog > CHANGELOG.rst
```

@alesdotio is that what you had in mind? Feel free to play with configuration in order to make it nicer.

It would also be nice to have:
- [x] A script/command that automatically bumps up version, generates new changelog, commits, adds tag and publishes to pypi